### PR TITLE
fix(ci): grant contents:write/pull-requests:write to the release wrappers

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,7 +1,8 @@
 name: Prepare Release
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release
 
 permissions:
-  contents: read
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
prepare-release.yaml's manual dispatch failed at startup (0 jobs scheduled) - both wrapper workflows only granted contents:read, but a caller's permissions block caps what a called reusable workflow can do. go-prepare-release.yaml needs contents:write + pull-requests:write; go-release.yaml needs contents:write.