### PR TITLE
chore(release): merge master into develop after v0.0.436

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.0.436 - 2026-07-23
+
+### Documentation
+- Update README (#139)
+
+### Fixed
+- Correct query-filter BSON marshaling and bump vulnerable deps (#138)
+
 ## [Unreleased]
 
 ### Added


### PR DESCRIPTION
Manual merge-back after the automated release workflow's merge-back step hit a CHANGELOG.md add/add conflict (release notes prepended above the H1 header vs. develop's Unreleased section). Resolved by reordering: released version section, then Unreleased.