### PR TITLE
fix(tracing): bump hardcoded semconv import to v1.41.0

### DIFF
--- a/tracing/setup.go
+++ b/tracing/setup.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
 )
 


### PR DESCRIPTION
## Summary
- `newTraceProvider` panics on startup for every consumer: `panic: conflicting Schema URL: https://opentelemetry.io/schemas/1.41.0 and https://opentelemetry.io/schemas/1.26.0`
- Root cause: `resource.Default()` (from `go.opentelemetry.io/otel/sdk` v1.44.0, currently pinned in go.mod) reports schema URL `1.41.0` internally. `newTraceProvider` merges that with a resource built via the hardcoded `semconv "go.opentelemetry.io/otel/semconv/v1.26.0"` import - `resource.Merge` rejects the mismatched schema URLs and the error is panic'd on instead of handled.
- Dependabot bumps `go.opentelemetry.io/otel/*` module *versions* in `go.mod` automatically, but a versioned semconv subpackage import path (`.../semconv/v1.26.0`) is source code Dependabot can't rewrite - it silently drifted out of sync with the SDK version as the module got bumped over time.
- Discovered via `catalog-api`'s pods stuck in `CrashLoopBackOff` after finally getting past an unrelated image-pull issue.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] Added a temporary local smoke test calling `newTraceProvider` directly and asserting no panic - passed after the fix, confirmed it panicked before the fix (not included in the PR diff, was throwaway verification)