### PR TITLE
fix(server): bound HealthHandler's Mongo calls with a timeout

### DIFF
--- a/server/status.go
+++ b/server/status.go
@@ -13,21 +13,30 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
+// healthCheckTimeout bounds each dependency check below so a stalled Mongo
+// operation fails the health check instead of hanging past the caller's
+// (e.g. a Kubernetes readiness probe's) own timeout indefinitely.
+const healthCheckTimeout = 5 * time.Second
+
 func HealthHandler(c context.Context) vo.HealthResponseVO {
 	var messages []string
 	errorCount := 0
 
-	_, span := otel.Tracer("health").Start(c, "list-collections")
-	collections, err := database.Db.ListCollectionNames(context.TODO(), bson.D{})
+	listCtx, cancel := context.WithTimeout(c, healthCheckTimeout)
+	defer cancel()
+	_, span := otel.Tracer("health").Start(listCtx, "list-collections")
+	collections, err := database.Db.ListCollectionNames(listCtx, bson.D{})
 	span.End()
 	if err != nil {
 		messages = append(messages, err.Error())
 		errorCount += 1
 	}
 
+	pingCtx, cancel := context.WithTimeout(c, healthCheckTimeout)
+	defer cancel()
 	start := time.Now()
-	_, span = otel.Tracer("health").Start(c, "ping-database")
-	err = database.Db.Client().Ping(c, readpref.Primary())
+	_, span = otel.Tracer("health").Start(pingCtx, "ping-database")
+	err = database.Db.Client().Ping(pingCtx, readpref.Primary())
 	span.End()
 	duration := time.Since(start)
 	if err != nil {


### PR DESCRIPTION
## Summary
- \`HealthHandler\`'s \`ListCollectionNames\` call used \`context.TODO()\` instead of the caller's
  context - completely unbounded, so a stalled Mongo operation hangs the health check forever
  with nothing able to cancel it, regardless of what timeout the caller (e.g. a Kubernetes
  readiness probe) expects.
- Discovered live: catalog-api pods sitting at \`0/1 Ready\`, \`RESTARTS=0\`, no errors in logs -
  \`/status/health\` itself just never responded (confirmed via \`wget --timeout=60\` from inside
  the pod: still no response). Raw TCP to the Mongo Atlas shard was reachable, DNS/SRV resolution
  worked fine - this was purely the missing timeout in application code.
- Both \`ListCollectionNames\` and \`Client().Ping\` now run under a bounded 5s timeout derived
  from the caller's context, so a stalled dependency fails the health check instead of hanging it.

## Test plan
- [x] \`go build ./...\`, \`go vet ./...\` pass
- [x] Existing \`go test ./...\` passes (no regression)