### PR TITLE
Add code coverage measurement and reporting

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,46 +7,11 @@ on:
       - develop
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   validate:
-    name: Validate on ${{ matrix.name }}
-
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux
-            os: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: recursive
-
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Check formatting
-        run: |
-          test -z "$(gofmt -l .)"
-
-      - name: Vet
-        run: |
-          go vet ./...
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: latest
-
-      - name: Test
-        run: |
-          go test -race ./...
+    uses: sweetrpg/github-actions/.github/workflows/go-ci.yaml@master
+    with:
+      publish-coverage: false
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # api-core.go
 
 [![CI](https://github.com/sweetrpg/api-core.go/actions/workflows/ci.yaml/badge.svg)](https://github.com/sweetrpg/api-core.go/actions/workflows/ci.yaml)
+[![Coverage](https://img.shields.io/endpoint?url=https://sweetrpg.github.io/api-core.go/coverage-badge.json)](https://sweetrpg.github.io/api-core.go/)
 [![License](https://img.shields.io/github/license/sweetrpg/api-core.go.svg)](https://img.shields.io/github/license/sweetrpg/api-core.go.svg)
 [![Issues](https://img.shields.io/github/issues/sweetrpg/api-core.go.svg)](https://img.shields.io/github/issues/sweetrpg/api-core.go.svg)
 [![PRs](https://img.shields.io/github/issues-pr/sweetrpg/api-core.go.svg)](https://img.shields.io/github/issues-pr/sweetrpg/api-core.go.svg)


### PR DESCRIPTION
Task 3.1 of the platform-wide code coverage rollout. ci.yaml already delegated to the shared
go-ci.yaml@master reusable workflow, which now includes coverage measurement, step summary,
artifact upload, warn-only threshold, and a GitHub Pages-hosted badge
(sweetrpg/github-actions#9, #10, #12) - this repo gets all of that automatically. Refactors
pr.yaml to delegate the same way (it previously duplicated the old inline steps by hand, with no
coverage), and adds the README badge.

Refs sweetrpg/platform#3
OpenSpec change: `openspec/changes/add-code-coverage/proposal.md` (in the `platform` umbrella repo)