### PR TITLE
Log health check failures instead of swallowing them silently

### DIFF
--- a/server/status.go
+++ b/server/status.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sweetrpg/api-core.go/vo"
+	"github.com/sweetrpg/common.go/logging"
 	"github.com/sweetrpg/mongodb.go/database"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -28,6 +29,7 @@ func HealthHandler(c context.Context) vo.HealthResponseVO {
 	collections, err := database.Db.ListCollectionNames(listCtx, bson.D{})
 	span.End()
 	if err != nil {
+		logging.Logger.Error("health check: list-collections failed", "database", database.Db.Name(), "error", err.Error())
 		messages = append(messages, err.Error())
 		errorCount += 1
 	}
@@ -40,6 +42,7 @@ func HealthHandler(c context.Context) vo.HealthResponseVO {
 	span.End()
 	duration := time.Since(start)
 	if err != nil {
+		logging.Logger.Error("health check: ping-database failed", "database", database.Db.Name(), "duration", duration.String(), "error", err.Error())
 		messages = append(messages, err.Error())
 		errorCount += 1
 	}


### PR DESCRIPTION
## Summary
- \`HealthHandler\` only ever surfaced Mongo failures in the JSON response body's \`Messages\`
  field - nothing reached application logs. A service stuck failing readiness for an extended
  period left no trace anywhere of why, beyond a generic 503.
- Logs both the \`list-collections\` and \`ping\` failure paths with the underlying driver error,
  matching this repo's existing \`logging.Logger.Error(...)\` convention.

Found while debugging a prolonged Mongo connectivity issue in dev where the only visibility into
*why* health checks were failing was reading the response body directly - nothing in the logs.

## Test plan
- [ ] Confirm log output appears for a simulated Mongo failure (e.g. wrong credentials)
- [ ] No change in behavior when health checks succeed