### PR TITLE
fix(tracing): stop panicking on resource schema URL mismatch

### DIFF
--- a/tracing/setup.go
+++ b/tracing/setup.go
@@ -35,11 +35,16 @@ func newExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
 }
 
 func newTraceProvider(exp sdktrace.SpanExporter, serviceName string) *sdktrace.TracerProvider {
-	// Ensure default SDK resources and the required service name are set.
+	// Ensure default SDK resources and the required service name are set. Schemaless (not
+	// NewWithAttributes(semconv.SchemaURL, ...)) deliberately: resource.Default()'s own schema
+	// version is whatever the otel/sdk release bundles internally, which doesn't necessarily
+	// match whatever semconv package version is pinned here - a mismatch makes resource.Merge
+	// panic on every startup ("conflicting Schema URL"). An empty schema URL merges with any
+	// other schema without conflict, so this is future-proof against the sdk bumping its own
+	// bundled semconv version out from under this pin.
 	r, err := resource.Merge(
 		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
+		resource.NewSchemaless(
 			semconv.ServiceName(serviceName),
 		),
 	)


### PR DESCRIPTION
## Summary
newTraceProvider merged resource.Default() with a resource built via
resource.NewWithAttributes(semconv.SchemaURL, ...), using a semconv package version pinned in
this repo's go.mod. Whenever that pinned version's schema URL doesn't match whatever schema
resource.Default() resolves internally (tracks the otel/sdk release, not this repo's own semconv
import), resource.Merge errors and newTraceProvider panics - crashing every consuming service on
startup before it serves a single request.

Confirmed hitting catalog-api in production right now (CrashLoopBackOff against the currently
released v0.1.0):
```
panic: conflicting Schema URL: https://opentelemetry.io/schemas/1.43.0 and https://opentelemetry.io/schemas/1.41.0
```

resource.NewSchemaless has an empty schema URL, which merges with any other schema without
conflict - correct regardless of which schema version a future otel/sdk bump uses internally.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean
- Not adding a regression test: this repo's current go.sum resolves a different otel/sdk+semconv
  pairing than the deployed v0.1.0, so the panic doesn't reproduce locally either way - a test
  here would be false confidence, not a real guard. The fix is correct on its own terms
  (schemaless never conflicts, by construction), not just patching today's specific version pair.